### PR TITLE
Gatk jar file as input

### DIFF
--- a/tools/GATK-ApplyRecalibration.cwl
+++ b/tools/GATK-ApplyRecalibration.cwl
@@ -9,6 +9,12 @@ hints:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   multithreading_nt:
     type: int
     default: 4
@@ -91,9 +97,9 @@ arguments:
    position: 2
    separate: false
    prefix: -Djava.io.tmpdir=
- - valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-   position: 3
-   prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
  - valueFrom: ApplyRecalibration
    position: 4
    prefix: -T

--- a/tools/GATK-BaseRecalibrator.cwl
+++ b/tools/GATK-BaseRecalibrator.cwl
@@ -9,6 +9,12 @@ hints:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   deletions_default_quality:
     type: int?
     inputBinding:
@@ -199,9 +205,9 @@ arguments:
   position: 2
   separate: false
   prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: BaseRecalibrator
   position: 4
   prefix: -T

--- a/tools/GATK-HaplotypeCaller.cwl
+++ b/tools/GATK-HaplotypeCaller.cwl
@@ -74,6 +74,12 @@ requirements:
 
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   max_alternate_alleles:
     type: int?
     inputBinding:
@@ -455,9 +461,9 @@ arguments:
   position: 2
   separate: false
   prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: HaplotypeCaller
   position: 4
   prefix: -T

--- a/tools/GATK-IndelRealigner.cwl
+++ b/tools/GATK-IndelRealigner.cwl
@@ -73,6 +73,12 @@ requirements:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   inputBam_realign:
     type: File
     inputBinding:
@@ -203,9 +209,9 @@ arguments:
   position: 2
   separate: false
   prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: IndelRealigner
   position: 4
   prefix: -T

--- a/tools/GATK-PrintReads.cwl
+++ b/tools/GATK-PrintReads.cwl
@@ -73,12 +73,16 @@ requirements:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   sample_file:
     type: File[]?
     inputBinding:
       position: 11
-
-
 
   reference:
     type: File
@@ -168,9 +172,9 @@ arguments:
   position: 2
   separate: false
   prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: PrintReads
   position: 4
   prefix: -T

--- a/tools/GATK-RealignTargetCreator.cwl
+++ b/tools/GATK-RealignTargetCreator.cwl
@@ -72,6 +72,12 @@ requirements:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   maxIntervalSize:
     type: int?
     inputBinding:
@@ -175,9 +181,9 @@ arguments:
   position: 2
   separate: false
   prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: RealignerTargetCreator
   position: 4
   prefix: -T

--- a/tools/GATK-SelectVariants.cwl
+++ b/tools/GATK-SelectVariants.cwl
@@ -24,6 +24,12 @@ hints:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   reference:
     type: File
     secondaryFiles:
@@ -75,10 +81,9 @@ outputs:
       doc: the selected variants as a vcf file
 
 arguments:
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
-
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: SelectVariants
   position: 4
   prefix: -T

--- a/tools/GATK-VariantFiltration.cwl
+++ b/tools/GATK-VariantFiltration.cwl
@@ -25,6 +25,12 @@ hints:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   reference:
     type: File
     secondaryFiles:
@@ -83,10 +89,9 @@ outputs:
       doc: the filtered vcf file
 
 arguments:
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
-
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: VariantFiltration
   position: 4
   prefix: -T

--- a/tools/GATK-VariantRecalibrator-SNPs.cwl
+++ b/tools/GATK-VariantRecalibrator-SNPs.cwl
@@ -32,6 +32,12 @@ hints:
 - $import: GATK-docker.yml
 
 inputs:
+  gatk_jar:
+    type: File
+    inputBinding:
+      position: 3
+      prefix: -jar
+
   haplotypecaller_snps_vcf:
     type: File
     inputBinding:
@@ -150,10 +156,9 @@ arguments:
 #  position: 2
 #  separate: false
 #  prefix: -Djava.io.tmpdir=
-- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
-  position: 3
-  prefix: -jar
-
+#- valueFrom: /usr/local/bin/GenomeAnalysisTK.jar
+#  position: 3
+#  prefix: -jar
 - valueFrom: VariantRecalibrator
   position: 4
   prefix: -T

--- a/tools/GATK-docker.yml
+++ b/tools/GATK-docker.yml
@@ -105,20 +105,20 @@ dockerFile: |
 
   ### INSTALL GATK
 
-  ENV VERSION "3.5"
-  ENV NAME "gatk-protected"
-  ENV URL https://github.com/broadgsa/gatk-protected/archive/${VERSION}.tar.gz
-
-  ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
-  ENV PATH /usr/lib/jvm/java-7-openjdk-amd64/bin:/usr/local/bin:$PATH
-
-  RUN wget -q -O - $URL | tar -zxv --strip-components=1 && \
-      grep -v "oracle.jrockit.jfr.StringConstantPool" /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.java >/tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.1.java && \
-      mv -f /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.1.java /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.java && \
-      mvn verify -Ddisable.shadepackage '-P!queue' && \
-      cd ./target/executable/ && \
-      cp -r ./ /usr/local/bin/ && \
-      cd /tmp && \
-      rm -rf ./* && \
-      bash -c 'echo -e "#!/bin/bash\njava -jar /usr/local/bin/GenomeAnalysisTK.jar  \$@" > /usr/local/bin/GenomeAnalysisTK' && \
-      chmod +x /usr/local/bin/GenomeAnalysisTK
+#  ENV VERSION "3.5"
+#  ENV NAME "gatk-protected"
+#  ENV URL https://github.com/broadgsa/gatk-protected/archive/${VERSION}.tar.gz
+#
+#  ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
+#  ENV PATH /usr/lib/jvm/java-7-openjdk-amd64/bin:/usr/local/bin:$PATH
+#
+#  RUN wget -q -O - $URL | tar -zxv --strip-components=1 && \
+#      grep -v "oracle.jrockit.jfr.StringConstantPool" /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.java >/tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.1.java && \
+#      mv -f /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.1.java /tmp/public/gatk-tools-public/src/main/java/org/broadinstitute/gatk/tools/walkers/varianteval/VariantEval.java && \
+#      mvn verify -Ddisable.shadepackage '-P!queue' && \
+#      cd ./target/executable/ && \
+#      cp -r ./ /usr/local/bin/ && \
+#      cd /tmp && \
+#      rm -rf ./* && \
+#      bash -c 'echo -e "#!/bin/bash\njava -jar /usr/local/bin/GenomeAnalysisTK.jar  \$@" > /usr/local/bin/GenomeAnalysisTK' && \
+#      chmod +x /usr/local/bin/GenomeAnalysisTK

--- a/workflows/GATK/GATK-Sub-Workflow-Workflow-h3abionet-haplotype.cwl
+++ b/workflows/GATK/GATK-Sub-Workflow-Workflow-h3abionet-haplotype.cwl
@@ -284,6 +284,7 @@ steps:
   IndelRealigner:
     run: ../../tools/GATK-IndelRealigner.cwl  # FIXME: this is draft 3
     in:
+      gatk_jar: gatk_jar
       outputfile_indelRealigner: outputFileName_IndelRealigner
       inputBam_realign: MarkDuplicates/markDups_output
       intervals: RealignTarget/output_realignTarget

--- a/workflows/GATK/GATK-Sub-Workflow-Workflow-h3abionet-haplotype.cwl
+++ b/workflows/GATK/GATK-Sub-Workflow-Workflow-h3abionet-haplotype.cwl
@@ -8,6 +8,10 @@ requirements:
   - class: InlineJavascriptRequirement
 
 inputs:
+  gatk_jar:
+    type: File
+    doc: Jar executable of the GATK tool
+
   reference:
     type: File
     doc: reference human genome file
@@ -269,6 +273,7 @@ steps:
   RealignTarget:
     run: ../../tools/GATK-RealignTargetCreator.cwl
     in:
+      gatk_jar: gatk_jar
       outputfile_realignTarget: outputFileName_RealignTargetCreator
       inputBam_realign: MarkDuplicates/markDups_output
       reference: uncompressed_reference
@@ -289,6 +294,7 @@ steps:
   BaseRecalibrator:
     run: ../../tools/GATK-BaseRecalibrator.cwl
     in:
+      gatk_jar: gatk_jar
       outputfile_BaseRecalibrator: outputFileName_BaseRecalibrator
       inputBam_BaseRecalibrator: IndelRealigner/output_indelRealigner
       reference: reference
@@ -300,6 +306,7 @@ steps:
   PrintReads:
     run: ../../tools/GATK-PrintReads.cwl  # FIXME: this is draft 3
     in:
+      gatk_jar: gatk_jar
       outputfile_printReads: outputFileName_PrintReads
       inputBam_printReads: IndelRealigner/output_indelRealigner
       reference: reference
@@ -310,6 +317,7 @@ steps:
   HaplotypeCaller:
     run: ../../tools/GATK-HaplotypeCaller.cwl  # FIXME: this is draft 3
     in:
+      gatk_jar: gatk_jar
       outputfile_HaplotypeCaller: outputFileName_HaplotypeCaller
       inputBam_HaplotypeCaller: PrintReads/output_printReads
       reference: reference

--- a/workflows/GATK/GATK-Sub-Workflow-h3abionet-indel-no-vqsr.cwl
+++ b/workflows/GATK/GATK-Sub-Workflow-h3abionet-indel-no-vqsr.cwl
@@ -10,6 +10,10 @@ requirements:
   - class: InlineJavascriptRequirement
 
 inputs:
+  gatk_jar:
+    type: File
+    doc: Jar executable of the GATK tool
+
   reference:
     type: File
     doc: reference human genome file
@@ -72,6 +76,7 @@ steps:
   select_indels:
     run: ../../tools/GATK-SelectVariants.cwl
     in:
+      gatk_jar: gatk_jar
       raw_vcf: haplotest_vcf
       reference: reference
       select_type: indel_mode
@@ -81,6 +86,7 @@ steps:
   filter_indels:
     run: ../../tools/GATK-VariantFiltration.cwl
     in:
+      gatk_jar: gatk_jar
       indels_vcf: select_indels/output_File
       reference: reference
       filter_expression: filter_expression

--- a/workflows/GATK/GATK-Sub-Workflow-h3abionet-snp.cwl
+++ b/workflows/GATK/GATK-Sub-Workflow-h3abionet-snp.cwl
@@ -8,6 +8,10 @@ requirements:
   - class: InlineJavascriptRequirement
 
 inputs:
+  gatk_jar:
+    type: File
+    doc: Jar executable of the GATK tool
+
   reference:
     type: File
     doc: reference human genome file
@@ -65,6 +69,7 @@ steps:
   vqsr_snps:
     run: ../../tools/GATK-VariantRecalibrator-SNPs.cwl
     in:
+      gatk_jar: gatk_jar
       haplotypecaller_snps_vcf: haplotest_vcf
       reference: reference
       resource_dbsnp: resource_dbsnp
@@ -76,6 +81,7 @@ steps:
   apply_recalibration_snps:
     run: ../../tools/GATK-ApplyRecalibration.cwl
     in:
+      gatk_jar: gatk_jar
       #raw_vcf: HaplotypeCaller/output_HaplotypeCaller
       raw_vcf: haplotest_vcf
       reference: reference

--- a/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.cwl
+++ b/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.cwl
@@ -69,6 +69,11 @@ doc: |
   [BAMStats](http://bamstats.sourceforge.net), is a simple software tool built on the Picard Java API (2), which can calculate and graphically display various metrics derived from SAM/BAM files of value in QC assessments.
 
 inputs:
+
+  gatk_jar:
+    type: File
+    doc: Jar executable of the GATK tool
+
   reference:
     type: File
     doc: reference human genome file
@@ -256,6 +261,7 @@ steps:
   HaplotypeCaller:
     run: GATK-Sub-Workflow-Workflow-h3abionet-haplotype.cwl
     in:
+      gatk_jar: gatk_jar
       reference: reference
       uncompressed_reference: uncompressed_reference
       reads: reads
@@ -292,6 +298,7 @@ steps:
   SnpVQSR:
     run: GATK-Sub-Workflow-h3abionet-snp.cwl
     in:
+      gatk_jar: gatk_jar
       reference: reference
       snpf_genome: snpf_genome
       snpf_nodownload: snpf_nodownload
@@ -308,6 +315,7 @@ steps:
   IndelFilter:
     run: GATK-Sub-Workflow-h3abionet-indel-no-vqsr.cwl
     in:
+      gatk_jar: gatk_jar
       reference: reference
       snpf_genome: snpf_genome
       snpf_nodownload: snpf_nodownload

--- a/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.json
+++ b/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.json
@@ -63,6 +63,10 @@
       "class" : "File"
    },
    "outputFileName_RealignTargetCreator" : "RealignTargetCreator-2017-04-23.intervals",
+   "gatk_jar" : {
+      "path" : "../../test/GenomeAnalysisTK.jar",
+      "class" : "File"
+   },
    "reference" : {
       "path" : "../../test/genome.fa",
       "class" : "File"

--- a/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.json
+++ b/workflows/GATK/GATK-complete-WES-Workflow-h3abionet.json
@@ -1,5 +1,5 @@
 {
-   "bwa_read_group" : "@RG\tID:1\tPL:ILLUMINA\tPU:pu\tLB:group1\tSM:SAMPLEID",
+   "bwa_read_group" : "@RG\tID:NA12878_test_sample\tPL:ILLUMINA\tPU:pu\tLB:group1\tSM:SAMPLEID",
    "createIndex_MarkDuplicates" : "true",
    "samtools-view-sambam" : "-Sb",
    "outputFileName_MarkDuplicates" : "MarkDuplicates-2017-04-23.bam",


### PR DESCRIPTION
`GATK 3.*` license restrict the sharing of its executable (JAR file) with non-academic users. As a workaround, in all `CWL` tools that use one of the GATK tools, a path to a local `GATK JAR file` is defined as a required `CWL` input.